### PR TITLE
fix: uninstall containerd, install docker and start docker

### DIFF
--- a/kubernetes/workspace_controller/workspace-api/app/utils/scripts.py
+++ b/kubernetes/workspace_controller/workspace-api/app/utils/scripts.py
@@ -185,6 +185,10 @@ def create_post_start_command():
                     sleep 2
                     rm -f /var/run/docker.pid
                     rm -f /var/run/docker.sock
+                    echo "Attempting to uninstall containerd and install Docker"
+                    sudo apt-get remove -y containerd
+                    sudo apt-get remove -y containerd.io
+                    sudo apt-get install -y docker.io
                     
                     start_docker_daemon
                     


### PR DESCRIPTION
I was getting these logs in `poststart.log`

```
Waiting for docker to start...
Docker daemon failed to start
WARNING: Could not fix Docker, it may not be available
```

1). `dockerd` was not starting
2). this was happening because `dockerd` was not installed
3). when you try to install `dockerd` it fails because `containerd` is installed
4). I uninstalled `containerd` installed `dockerd` and then started `dockerd`

This should resolve the issue I was facing

---

I'm not super familiar with the code so if there is another location to add this logic then I can add it there